### PR TITLE
Uniformize join event names

### DIFF
--- a/src/lib/bars/chart-bar-grouped.ts
+++ b/src/lib/bars/chart-bar-grouped.ts
@@ -79,7 +79,7 @@ export function chartBarGrouped<
         .call((s) => legend(s))
         .layout('margin', '0.5rem')
         .layout('justify-content', 'flex-end')
-        .on('legenditementer.chartbargrouped', (e: JoinEvent<SVGGElement, DataLegendItem>) => {
+        .on('enter.chartbargrouped', (e: JoinEvent<SVGGElement, DataLegendItem>) => {
           e.detail.selection.on(
             'mouseover.chartbargroupedhighlight mouseout.chartbargroupedhighlight',
             (e) => {

--- a/src/lib/bars/series-bar.ts
+++ b/src/lib/bars/series-bar.ts
@@ -170,7 +170,7 @@ export function seriesBarRender<
             .append('rect')
             .classed('bar', true)
             .call((s) => rectToAttrs(s, (d) => rectMinimized(d)))
-            .call((s) => selection.dispatch('barenter', { detail: { selection: s } })),
+            .call((s) => selection.dispatch('enter', { detail: { selection: s } })),
         undefined,
         (exit) =>
           exit
@@ -182,7 +182,7 @@ export function seriesBarRender<
                 .call((t) => rectToAttrs(t, (d) => rectMinimized(d)))
                 .remove()
             )
-            .call((s) => selection.dispatch('barexit', { detail: { selection: s } }))
+            .call((s) => selection.dispatch('exit', { detail: { selection: s } }))
       )
       .call((s) =>
         s
@@ -194,7 +194,7 @@ export function seriesBarRender<
       .attr('fill', (d, i, g) => d.color)
       .attr('stroke-width', (d) => d.strokeWidth)
       .attr('stroke', (d) => d.stroke)
-      .call((s) => selection.dispatch('barupdate', { detail: { selection: s } }));
+      .call((s) => selection.dispatch('update', { detail: { selection: s } }));
   });
 }
 

--- a/src/lib/bars/series-label.ts
+++ b/src/lib/bars/series-label.ts
@@ -71,7 +71,7 @@ export function seriesLabelRender<
             .call((s) =>
               s.transition('enter').duration(250).attr('font-size', '1em').attr('opacity', 1)
             )
-            .call((s) => selection.dispatch('labelenter', { detail: { selection: s } })),
+            .call((s) => selection.dispatch('enter', { detail: { selection: s } })),
         undefined,
         (exit) =>
           exit
@@ -84,7 +84,7 @@ export function seriesLabelRender<
                 .attr('opacity', 0)
                 .remove()
             )
-            .call((s) => selection.dispatch('labelexit', { detail: { selection: s } }))
+            .call((s) => selection.dispatch('exit', { detail: { selection: s } }))
       )
       .call((s) =>
         s
@@ -94,7 +94,7 @@ export function seriesLabelRender<
           .call((t) => positionToTransformAttr(t, (d) => d))
       )
       .text((d) => d.text)
-      .call((s) => selection.dispatch('labelupdate', { detail: { selection: s } }));
+      .call((s) => selection.dispatch('update', { detail: { selection: s } }));
   });
 }
 

--- a/src/lib/chart-window/series-checkbox.ts
+++ b/src/lib/chart-window/series-checkbox.ts
@@ -55,17 +55,17 @@ export function seriesCheckbox(selection: Selection<HTMLElement, DataSeriesCheck
                 s.append('input').attr('type', 'checkbox').attr('id', id);
                 s.append('label').attr('for', id);
               })
-              .call((s) => series.dispatch('checkboxenter', { detail: { selection: s } })),
+              .call((s) => series.dispatch('enter', { detail: { selection: s } })),
           undefined,
           (exit) =>
-            exit.remove().call((s) => series.dispatch('checkboxexit', { detail: { selection: s } }))
+            exit.remove().call((s) => series.dispatch('exit', { detail: { selection: s } }))
         )
         .each((d, i, g) => {
           const s = select(g[i]);
           s.selectChildren('input').property('checked', d.checked);
           s.selectChildren('label').text(d.label);
         })
-        .call((s) => series.dispatch('checkboxupdate', { detail: { selection: s } }));
+        .call((s) => series.dispatch('update', { detail: { selection: s } }));
     })
     .dispatch('datachange');
 }

--- a/src/lib/legend/legend.ts
+++ b/src/lib/legend/legend.ts
@@ -56,7 +56,7 @@ export function legend<
         .append('filter')
         .call((s) => filterBrightness(s, 1.3))
     )
-    .on('legenditementer.legend', (e: JoinEvent<SVGGElement, DataLegendItem>) => {
+    .on('enter.legend', (e: JoinEvent<SVGGElement, DataLegendItem>) => {
       e.detail.selection.on('mouseover.legend mouseout.legend', (e) => {
         legendItemHighlight(select(e.currentTarget), e.type.endsWith('over'));
       });
@@ -98,12 +98,12 @@ export function legend<
                   .classed('label', true)
                   .call((s) => textHorizontalAttrs(s))
               )
-              .call((s) => legend.dispatch('legenditementer', { detail: { selection: s } })),
+              .call((s) => legend.dispatch('enter', { detail: { selection: s } })),
           undefined,
           (exit) =>
             exit
               .remove()
-              .call((s) => legend.dispatch('legenditemexit', { detail: { selection: s } }))
+              .call((s) => legend.dispatch('exit', { detail: { selection: s } }))
         )
         .call((s) =>
           s
@@ -113,7 +113,7 @@ export function legend<
             )
         )
         .call((s) => s.select('.label').text((d) => d.label.toString()))
-        .call((s) => legend.dispatch('legenditemupdate', { detail: { selection: s } }));
+        .call((s) => legend.dispatch('update', { detail: { selection: s } }));
     });
 }
 

--- a/src/lib/points/series-point.ts
+++ b/src/lib/points/series-point.ts
@@ -110,7 +110,7 @@ export function seriesPointRender<
             .attr('cx', (d) => d.x)
             .attr('cy', (d) => d.y)
             .attr('r', 0)
-            .call((s) => selection.dispatch('pointenter', { detail: { selection: s } })),
+            .call((s) => selection.dispatch('enter', { detail: { selection: s } })),
         undefined,
         (exit) =>
           exit
@@ -124,7 +124,7 @@ export function seriesPointRender<
                 .attr('r', 0)
                 .remove()
             )
-            .call((s) => selection.dispatch('pointexit', { detail: { selection: s } }))
+            .call((s) => selection.dispatch('exit', { detail: { selection: s } }))
       )
       .call((s) =>
         s
@@ -135,6 +135,6 @@ export function seriesPointRender<
           .attr('cy', (d) => d.y)
           .attr('r', (d) => d.radius)
       )
-      .call((s) => selection.dispatch('pointupdate', { detail: { selection: s } }));
+      .call((s) => selection.dispatch('update', { detail: { selection: s } }));
   });
 }


### PR DESCRIPTION
Uniformize join event names of series.

e.g. barenter, barupdate, barexit, pointenter, pointupdate, pointexit ... → enter, update, exit

Closes #14 