### PR TITLE
Add highlighting to stacked bar chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add barFind function to find bars by key.
 - Add barFindByIndex function.
 - Add barGroupedFindByGroupIndex function.
+- Add barStackedFindByStackIndex function.
 - Add labelFind function find labels by key.
 - Add labelFindByIndex function.
 - Add labelFindByFilter function.
@@ -51,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add automatic highlighting of legend items on hover to legend.
 - Add automatic highlighting of bars, labels and main axis ticks to chartBar.
 - Add automatic highlighting of bars, labels, main axis ticks and legend items to chartBarGrouped.
+- Add automatic highlighting of bars, labels, main axis ticks and legend items to chartBarStacked.
 - Add Selection.properties function.
   - Get an array of a property from all elements in a selection.
 - Add Selection.closest function.

--- a/src/examples/stacked-bar.html
+++ b/src/examples/stacked-bar.html
@@ -82,17 +82,16 @@
         const narrow = !window.matchMedia(wideMediaQuery).matches;
         const flippedBars = narrow;
         const chartFlexDirection = narrow ? 'column-reverse' : 'row';
-        const legendFlexDirection = narrow ? 'row' : 'column';
-        const legendJustifyContent = narrow ? 'flex-end' : 'flex-start';
+        const legendAlignSelf = narrow ? 'flex-end' : 'flex-start';
+        const legendItemsFlexDirection = narrow ? 'row' : 'column';
 
-        chartDatum.flipped = flippedBars;
+        chart.datum((d) => Object.assign(d, { flipped: flippedBars }));
 
         chart.layout('flex-direction', chartFlexDirection);
         legend
-          .layout('flex-direction', legendFlexDirection)
-          .layout('justify-content', legendJustifyContent);
-
-        chart.datum(chartDatum);
+          .layout('align-self', legendAlignSelf)
+          .selectAll('.items')
+          .layout('flex-direction', legendItemsFlexDirection);
       }
     </script>
   </body>

--- a/src/examples/stacked-bar.html
+++ b/src/examples/stacked-bar.html
@@ -60,6 +60,9 @@
             subtitle: '[%]',
             configureAxis: (a) => a.tickFormat(formatShare),
           },
+          legend: {
+            title: 'Platforms'
+          }
         }),
         chart = layouter.append('svg').datum(chartDatum).call(respVis.chartBarStacked),
         barSeries = chart.selectAll('.series-bar'),

--- a/src/lib/bars/chart-bar-grouped.ts
+++ b/src/lib/bars/chart-bar-grouped.ts
@@ -79,16 +79,11 @@ export function chartBarGrouped<
         .call((s) => legend(s))
         .layout('margin', '0.5rem')
         .layout('justify-content', 'flex-end')
-        .on('enter.chartbargrouped', (e: JoinEvent<SVGGElement, DataLegendItem>) => {
-          e.detail.selection.on(
-            'mouseover.chartbargroupedhighlight mouseout.chartbargroupedhighlight',
-            (e) => {
-              chartBarGroupedHoverLegendItem(
-                chart,
-                select(e.currentTarget),
-                e.type.endsWith('over')
-              );
-            }
+        .on('mouseover.chartbargroupedhighlight mouseout.chartbargroupedhighlight', (e) => {
+          chartBarGroupedHoverLegendItem(
+            chart,
+            select(e.target.closest('.legend-item')),
+            e.type.endsWith('over')
           );
         });
     })
@@ -143,8 +138,9 @@ export function chartBarGroupedDataChange<
     yAxis.scale = valueScale;
     chartCartesianUpdateAxes(s);
 
-    s.selectAll(`.axis-x .tick`).on('mouseover mouseout', (e) =>
-      chartBarGroupedHoverAxisTick(s, select(e.currentTarget), e.type.endsWith('over'))
+    s.selectAll(`.axis-x .tick`).on(
+      'mouseover.chartbargroupedhighlight mouseout.chartbargroupedhighlight',
+      (e) => chartBarGroupedHoverAxisTick(s, select(e.currentTarget), e.type.endsWith('over'))
     );
   });
 }

--- a/src/lib/bars/series-bar-stacked.ts
+++ b/src/lib/bars/series-bar-stacked.ts
@@ -5,6 +5,7 @@ import {
   arrayIs2D,
   COLORS_CATEGORICAL,
   DataSeriesGenerator,
+  findByDataProperty,
   Rect,
   rectFitStroke,
 } from '../core';
@@ -128,4 +129,11 @@ export function seriesBarStacked<
   selection: Selection<GElement, Datum, PElement, PDatum>
 ): Selection<GElement, Datum, PElement, PDatum> {
   return seriesBar(selection).classed('series-bar-stacked', true);
+}
+
+export function barStackedFindByStackIndex(
+  container: Selection,
+  index: number
+): Selection<SVGRectElement, DataBarStacked> {
+  return findByDataProperty<SVGRectElement, DataBarStacked>(container, '.bar', 'stackIndex', index);
 }


### PR DESCRIPTION
This PR adds highlighting to stacked bar charts when hovering over bars, category axis ticks or legend items. It also fixes the layouting of the legend in the stacked bar chart example.

![p6y7R0MTg5](https://user-images.githubusercontent.com/4006346/127041448-1e76e596-8dbe-4028-a19c-2186488ce76c.gif)

Closes #18 
